### PR TITLE
Optimisations for swift

### DIFF
--- a/ReactiveCoreData/NSManagedObject+ReactiveCoreData.m
+++ b/ReactiveCoreData/NSManagedObject+ReactiveCoreData.m
@@ -35,7 +35,7 @@
 
 + (NSString *)entityName;
 {
-    return NSStringFromClass(self);
+    return [[NSStringFromClass(self)  componentsSeparatedByString:@"."] lastObject];
 }
 
 + (instancetype)insert;

--- a/ReactiveCoreData/RACSignal+ReactiveCoreData.h
+++ b/ReactiveCoreData/RACSignal+ReactiveCoreData.h
@@ -26,7 +26,7 @@
 - (RACSignal *)count;
 
 // Modifies NSFetchRequest to set predicate
-- (RACSignal *)where:(id)predicateOrSignal;
+- (RACSignal *)whereObjectMatches:(id)predicateOrSignal;
 
 // Returns a signal with NSFetchRequest's predicate modified according to format and its arguments
 //
@@ -35,12 +35,12 @@
 // Any new value in any of the argument signals will result in update of the fetch request
 // and possible execution of the request, if there's a `fetch` later.
 // This brings the predicates into the reactive world
-- (RACSignal *)where:(NSString *)format args:(NSArray *)args;
+- (RACSignal *)whereObjectMatches:(NSString *)format args:(NSArray *)args;
 
 // A convenience method for a common predicate case
 //
 // Create a "%K == %@" predicate with key and value as arguments
-- (RACSignal *)where:(id)key equals:(id)value;
+- (RACSignal *)whereObjectMatches:(id)key equals:(id)value;
 
 // A convenience method for a common predicate case
 //
@@ -50,7 +50,7 @@
 // This is useful when the using it to filter text from the search field, which can be empty
 // `options` parameter is an optional string like `@"cd"` that can be added after CONTAINS inside brackets.
 // For example, passing @"cd" for `options` will result in a CONTAINS[cd] predicate
-- (RACSignal *)where:(id)key contains:(id)valueOrSignal options:(NSString *)optionsOrNil;
+- (RACSignal *)whereObjectMatches:(id)key contains:(id)valueOrSignal options:(NSString *)optionsOrNil;
 
 // Modifies the NSFetchRequest to set passed-in limit
 - (RACSignal *)limit:(id)limitOrSignal;

--- a/ReactiveCoreData/RACSignal+ReactiveCoreData.h
+++ b/ReactiveCoreData/RACSignal+ReactiveCoreData.h
@@ -27,7 +27,7 @@
 
 // Modifies NSFetchRequest to set predicate
 - (RACSignal *)whereObjectMatches:(id)predicateOrSignal;
-
+ 
 // Returns a signal with NSFetchRequest's predicate modified according to format and its arguments
 //
 // The format is passed to NSPredicate as is

--- a/ReactiveCoreData/RACSignal+ReactiveCoreData.m
+++ b/ReactiveCoreData/RACSignal+ReactiveCoreData.m
@@ -18,7 +18,7 @@
             return [[moc executeRequest:req] map:^id(id value) {
                 return [value lastObject];
             }];
-        }
+        } 
         else {
             return [moc executeRequest:req];
         }

--- a/ReactiveCoreData/RACSignal+ReactiveCoreData.m
+++ b/ReactiveCoreData/RACSignal+ReactiveCoreData.m
@@ -46,7 +46,7 @@
 
 #pragma mark - Operations modifying NSFetchRequest
 
-- (RACSignal *)where:(id)predicateOrSignal;
+- (RACSignal *)whereObjectMatches:(id)predicateOrSignal;
 {
     RACSignal *predicateSignal = [self rcd_convertToSignal:predicateOrSignal];
     return [[[self combineLatestWith:predicateSignal]
@@ -56,12 +56,12 @@
         }] setNameWithFormat:@"[%@] -where:%@", self.name, predicateOrSignal];
 }
 
-- (RACSignal *)where:(id)key equals:(id)value;
+- (RACSignal *)whereObjectMatches:(id)key equals:(id)value;
 {
     return [self where:@"%K == %@" args:@[key, value]];
 }
 
-- (RACSignal *)where:(NSString *)format args:(NSArray *)args;
+- (RACSignal *)whereObjectMatches:(NSString *)format args:(NSArray *)args;
 {
     NSArray *signals = [self rcd_convertToSignals:args];
     return [[[self combineLatestWith:[RACSignal combineLatest:signals]]
@@ -72,7 +72,7 @@
         }] setNameWithFormat:@"[%@] -where:%@ args:%@", self.name, format, args];
 }
 
-- (RACSignal *)where:(id)key contains:(id)valueOrSignal options:(NSString *)optionsOrNil;
+- (RACSignal *)whereObjectMatches:(id)key contains:(id)valueOrSignal options:(NSString *)optionsOrNil;
 {
     NSParameterAssert(valueOrSignal);
     NSParameterAssert(key);

--- a/ReactiveCoreData/RACSignal+ReactiveCoreData.m
+++ b/ReactiveCoreData/RACSignal+ReactiveCoreData.m
@@ -58,7 +58,7 @@
 
 - (RACSignal *)whereObjectMatches:(id)key equals:(id)value;
 {
-    return [self where:@"%K == %@" args:@[key, value]];
+    return [self whereObjectMatches:@"%K == %@" args:@[key, value]];
 }
 
 - (RACSignal *)whereObjectMatches:(NSString *)format args:(NSArray *)args;
@@ -86,7 +86,7 @@
                 else {
                     whereClause = @"%K CONTAINS %@";
                 }
-                return [self where:whereClause args:@[key, filter]];
+                return [self whereObjectMatches:whereClause args:@[key, filter]];
             }
             else
                 return self;


### PR DESCRIPTION
I've changed the "where"-functions in RACSignal+ReactiveCoreData to avoid overlap with the swift keyword "where". 

In NSManagedObject+ReactiveCoreData i changed the way the entity name is build, 
with the StringFromClass()-methode swift will get a classname like "AppName.EntityName" which wont work for object creation. 
